### PR TITLE
회원 API 및 게시판 일부 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation ("org.springframework.boot:spring-boot-starter-validation")
 
+	// https://mvnrepository.com/artifact/com.auth0/java-jwt
+	implementation group: 'com.auth0', name: 'java-jwt', version: '3.13.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/example/hobbyproject/controller/UserController.java
+++ b/src/main/java/com/example/hobbyproject/controller/UserController.java
@@ -1,0 +1,145 @@
+package com.example.hobbyproject.controller;
+
+import com.example.hobbyproject.entity.PostLike;
+import com.example.hobbyproject.error.CreateResponseError;
+import com.example.hobbyproject.model.*;
+import com.example.hobbyproject.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserService userService;
+
+    // 특정 회원 정보 조회(보안상 비밀번호, 가입일, 회원 정보 수정일 노출 X)
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponse> getUserById(@PathVariable Long id) {
+
+        UserResponse userResponse = userService.getUserById(id);
+
+        return ResponseEntity.ok(userResponse);
+    }
+
+    // 특정 회원이 작성한 글 목록 반환
+    @GetMapping("/{list}/{id}")
+    public ResponseEntity<List<PostResponse>> getPostsByUserId(@PathVariable Long id) {
+
+        List<PostResponse> postsByUserId = userService.getPostsByUserId(id);
+
+        return ResponseEntity.ok(postsByUserId);
+    }
+
+    // 회원 등록
+    @PostMapping("/register")
+    public ResponseEntity<Object> registerUser(@RequestBody @Valid UserInput userInput,
+                                               Errors errors) {
+
+        //필수 항목 미입력시 에러 처리(Object는 FieldError 반환)
+        if (errors.hasErrors()) {
+            List<CreateResponseError> responseErrors = new ArrayList<>();
+
+            errors.getAllErrors().forEach(e -> {
+                responseErrors.add(CreateResponseError.of((FieldError) e));
+            });
+            return new ResponseEntity<>(responseErrors, HttpStatus.BAD_REQUEST);
+        }
+
+        UserModel registeredUser = userService.registerUser(userInput);
+
+        return ResponseEntity.ok(registeredUser);
+
+    }
+
+    // 회원 정보 수정
+    @PutMapping("/update/{id}")
+    public ResponseEntity<UserModel> updateUser(@PathVariable Long id,
+                                                @RequestBody @Valid UserUpdate userUpdate) {
+
+        UserModel updatedUser = userService.updateUser(id, userUpdate);
+
+        return ResponseEntity.ok(updatedUser);
+    }
+
+    // 비밀번호 수정
+    @PatchMapping("/password/{id}")
+    public ResponseEntity<?> updateUserPassword(@PathVariable Long id,
+                                                @RequestBody @Valid UserInputPassword userInputPassword,
+                                                Errors errors) {
+
+        if (errors.hasErrors()) {
+            List<CreateResponseError> responseErrors = new ArrayList<>();
+
+            errors.getAllErrors().forEach(e -> {
+                responseErrors.add(CreateResponseError.of((FieldError) e));
+            });
+            return new ResponseEntity<>(responseErrors, HttpStatus.BAD_REQUEST);
+        }
+
+        UserModel updateUserPassword = userService.updateUserPassword(id, userInputPassword);
+
+        return ResponseEntity.ok(updateUserPassword);
+    }
+
+    // 회원 삭제(성매매,불법도박 등 범죄 후기글. 회원 정보는 삭제하지만, 그 사람이 쓴 글은 추론 할 수 있게 남겨둠.
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<UserModel> deleteUser(@PathVariable Long id) {
+        UserModel deletedUser = userService.deleteUser(id);
+        return ResponseEntity.ok(deletedUser);
+    }
+
+    // 회원 ID(이메일)을 찾기(이름과 전화번호에 해당하는 이메일을 찾는다)
+    @GetMapping("/find")
+    public ResponseEntity<UserResponse> findUser(@RequestBody UserInputFind userInputFind) {
+
+        UserResponse userResponse = userService.findUser(userInputFind);
+
+        return ResponseEntity.ok(userResponse);
+
+    }
+
+    // 회원 비밀번호 초기화
+    @GetMapping("/password/reset/{id}")
+    public ResponseEntity<UserModel> resetUserPassword(@PathVariable Long id) {
+
+        UserModel userModel = userService.resetUserPassword(id);
+
+        return ResponseEntity.ok(userModel);
+    }
+
+    // 내가 좋아요한 게시글을 보는 API
+    @GetMapping("/posts/like/{id}")
+    public ResponseEntity<List<PostLike>> likePost(@PathVariable Long id) {
+
+        List<PostLike> postLikeList = userService.likePost(id);
+
+        return ResponseEntity.ok(postLikeList);
+    }
+
+    // JWT 토큰 발행 API(회원 이메일, 비밀번호 이용)
+    @PostMapping("/login")
+    public ResponseEntity<?> createToken(@RequestBody @Valid UserLogin userLogin,
+                                         Errors errors) {
+
+        List<CreateResponseError> responseErrorList = new ArrayList<>();
+
+        if (errors.hasErrors()) {
+            errors.getAllErrors().forEach(e -> responseErrorList.add(CreateResponseError.of((FieldError) e)));
+            return new ResponseEntity<>(responseErrorList, HttpStatus.BAD_REQUEST);
+        }
+
+        UserLoginToken token = userService.createToken(userLogin);
+        return ResponseEntity.ok(token);
+    }
+
+}

--- a/src/main/java/com/example/hobbyproject/entity/Post.java
+++ b/src/main/java/com/example/hobbyproject/entity/Post.java
@@ -2,11 +2,7 @@ package com.example.hobbyproject.entity;
 
 
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,6 +21,10 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
     private long id;
+
+    @ManyToOne
+    @JoinColumn
+    private User user;
 
     //글 작성 시 동일 제목, 내용 방지(중복 제거)
     @Column(unique = true)

--- a/src/main/java/com/example/hobbyproject/entity/PostLike.java
+++ b/src/main/java/com/example/hobbyproject/entity/PostLike.java
@@ -1,0 +1,32 @@
+package com.example.hobbyproject.entity;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Entity
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @JoinColumn
+    @ManyToOne
+    private Post post;
+
+    @JoinColumn
+    @ManyToOne
+    private User user;
+
+
+}

--- a/src/main/java/com/example/hobbyproject/entity/User.java
+++ b/src/main/java/com/example/hobbyproject/entity/User.java
@@ -1,0 +1,45 @@
+package com.example.hobbyproject.entity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column
+    private String email;
+
+    @Column
+    private String userName;
+
+    @Column
+    private String password;
+
+    @Column
+    private String phone;
+
+    @Column
+    private LocalDateTime regDate;
+
+    @Column
+    private LocalDateTime updateDate;
+
+//    @Column
+//    private UserStatus status;
+
+    @Column
+    private boolean lockYn;
+
+}

--- a/src/main/java/com/example/hobbyproject/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/hobbyproject/exception/GlobalExceptionHandler.java
@@ -12,4 +12,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(exception.getMessage(), exception.getHttpStatus());
     }
 
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<String> handleUserException(UserException userException) {
+        return new ResponseEntity<>(userException.getMessage(), userException.getHttpStatus());
+    }
+
 }

--- a/src/main/java/com/example/hobbyproject/exception/UserException.java
+++ b/src/main/java/com/example/hobbyproject/exception/UserException.java
@@ -1,0 +1,19 @@
+package com.example.hobbyproject.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class UserException extends RuntimeException{
+
+    private final UserExceptionType userExceptionType;
+
+    public UserException(UserExceptionType userExceptionType) {
+        super(userExceptionType.getMessage());
+        this.userExceptionType = userExceptionType;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return this.userExceptionType.getHttpStatus();
+    }
+}

--- a/src/main/java/com/example/hobbyproject/exception/UserExceptionType.java
+++ b/src/main/java/com/example/hobbyproject/exception/UserExceptionType.java
@@ -1,0 +1,18 @@
+package com.example.hobbyproject.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserExceptionType {
+
+    USER_NOT_FOUND("사용자 정보가 없습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATE_EMAIL("이미 존재하는 이메일 주소입니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+}

--- a/src/main/java/com/example/hobbyproject/model/PostResponse.java
+++ b/src/main/java/com/example/hobbyproject/model/PostResponse.java
@@ -1,0 +1,44 @@
+package com.example.hobbyproject.model;
+
+import com.example.hobbyproject.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponse {
+
+    private long id;
+
+    private long regUserId;
+    private String regUserName;
+
+    private String title;
+    private String contents;
+    private String writer;
+    private LocalDateTime regDate;
+    private LocalDateTime updateDate;
+    private int hits;
+    private int likes;
+
+    public static PostResponse of(Post post) {
+        return PostResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .writer(post.getWriter())
+                .contents(post.getContents())
+                .regDate(post.getRegDate())
+                .regUserId(post.getUser().getId())
+                .regUserName(post.getUser().getUserName())
+                .updateDate(post.getUpdateDate())
+                .hits(post.getHits())
+                .likes(post.getLikes())
+                .build();
+    }
+}

--- a/src/main/java/com/example/hobbyproject/model/UserInput.java
+++ b/src/main/java/com/example/hobbyproject/model/UserInput.java
@@ -1,0 +1,33 @@
+package com.example.hobbyproject.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class UserInput {
+
+    @Email(message = "이메일 형식에 맞게 입력해 주세요.")
+    @NotBlank(message = "이메일은 필수 항목 입니다.")
+    private String email;
+
+    @NotBlank(message = "이름은 필수 항목 입니다.")
+    private String userName;
+
+    @Size(min = 4, message = "비밀번호는 4자 이상 입력해야 합니다.")
+    @NotBlank(message = "비밀번호는 필수 항목 입니다.")
+    private String password;
+
+    @Size(max = 20, message = "연락처는 최대 20자까지 입력해야 합니다.")
+    @NotBlank(message = "연락처는 필수 항목 입니다.")
+    private String phone;
+
+}

--- a/src/main/java/com/example/hobbyproject/model/UserInputFind.java
+++ b/src/main/java/com/example/hobbyproject/model/UserInputFind.java
@@ -5,14 +5,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
 @Data
-public class PostUpdateInput {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInputFind {
 
-  private String title;
-  private String contents;
-  private String writer;
+    private String userName;
+    private String phone;
 
 }

--- a/src/main/java/com/example/hobbyproject/model/UserInputPassword.java
+++ b/src/main/java/com/example/hobbyproject/model/UserInputPassword.java
@@ -1,0 +1,25 @@
+package com.example.hobbyproject.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class UserInputPassword {
+
+    @NotBlank(message = "현재 비밀번호는 필수 항목입니다.")
+    private String password;
+
+    @Size(min = 4, max = 20, message = "신규 비밀번호는 4-20사이의 길이로 입력해 주세요.")
+    @NotBlank(message = "신규 비밀번호는 필수 항목입니다.")
+    private String newPassword;
+
+}

--- a/src/main/java/com/example/hobbyproject/model/UserLogin.java
+++ b/src/main/java/com/example/hobbyproject/model/UserLogin.java
@@ -1,0 +1,21 @@
+package com.example.hobbyproject.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserLogin {
+
+    @NotBlank(message = "이메일 항목은 필수 입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호 항목은 필수 입니다.")
+    private String password;
+}

--- a/src/main/java/com/example/hobbyproject/model/UserLoginToken.java
+++ b/src/main/java/com/example/hobbyproject/model/UserLoginToken.java
@@ -5,14 +5,12 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @Data
-public class PostUpdateInput {
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserLoginToken {
 
-  private String title;
-  private String contents;
-  private String writer;
+    private String token;
 
 }

--- a/src/main/java/com/example/hobbyproject/model/UserModel.java
+++ b/src/main/java/com/example/hobbyproject/model/UserModel.java
@@ -1,0 +1,36 @@
+package com.example.hobbyproject.model;
+
+import com.example.hobbyproject.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserModel {
+
+    private Long id;
+    private String email;
+    private String userName;
+    private String password;
+    private String phone;
+    private LocalDateTime regDate;
+    private LocalDateTime updateDate;
+
+    public static UserModel fromEntity(User user) {
+        return UserModel.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .userName(user.getUserName())
+                .password(user.getPassword())
+                .phone(user.getPhone())
+                .regDate(user.getRegDate())
+                .updateDate(user.getUpdateDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/hobbyproject/model/UserResponse.java
+++ b/src/main/java/com/example/hobbyproject/model/UserResponse.java
@@ -1,0 +1,28 @@
+package com.example.hobbyproject.model;
+
+import com.example.hobbyproject.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class UserResponse {
+
+    private long id;
+    private String email;
+    private String userName;
+    protected String phone;
+
+    public static UserResponse of(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .userName(user.getUserName())
+                .phone(user.getPhone())
+                .build();
+    }
+}

--- a/src/main/java/com/example/hobbyproject/model/UserUpdate.java
+++ b/src/main/java/com/example/hobbyproject/model/UserUpdate.java
@@ -1,0 +1,21 @@
+package com.example.hobbyproject.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class UserUpdate {
+
+    @Size(max = 20, message = "연락처는 최대 20자까지 입력해야 합니다.")
+    @NotBlank(message = "연락처는 필수 항목 입니다.")
+    private String phone;
+
+}

--- a/src/main/java/com/example/hobbyproject/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/hobbyproject/repository/PostLikeRepository.java
@@ -1,0 +1,15 @@
+package com.example.hobbyproject.repository;
+
+import com.example.hobbyproject.entity.PostLike;
+import com.example.hobbyproject.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    List<PostLike> findByUser(User user);
+
+}

--- a/src/main/java/com/example/hobbyproject/repository/PostRepository.java
+++ b/src/main/java/com/example/hobbyproject/repository/PostRepository.java
@@ -1,8 +1,7 @@
 package com.example.hobbyproject.repository;
 
 import com.example.hobbyproject.entity.Post;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import com.example.hobbyproject.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,13 +11,13 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-  // 특정 ID 리스트에 해당하는 게시글 모두 삭제(데이터가 있을지 없을지 모르니 Optional)
-  Optional<List<Post>> findByIdIn(List<Long> idList);
+    // 특정 ID 리스트에 해당하는 게시글 모두 삭제(데이터가 있을지 없을지 모르니 Optional)
+    Optional<List<Post>> findByIdIn(List<Long> idList);
 
-  // 글 작성 시 동일 제목, 내용 방지(중복 제거)
-  boolean existsByTitleOrContents(String title, String contents);
+    // 글 작성 시 동일 제목, 내용 방지(중복 제거)
+    boolean existsByTitleOrContents(String title, String contents);
 
-
-
+    // 특정 사용자가 작성한 게시글 목록을 가져옴
+    List<Post> findByUser(User user);
 
 }

--- a/src/main/java/com/example/hobbyproject/repository/UserRepository.java
+++ b/src/main/java/com/example/hobbyproject/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.example.hobbyproject.repository;
+
+import com.example.hobbyproject.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByIdAndPassword(Long id, String password);
+
+    // 회원 ID(이메일)을 찾기(이름과 전화번호에 해당하는 이메일을 찾는다)
+    Optional<User> findByUserNameAndPhone(String userName, String phone);
+}

--- a/src/main/java/com/example/hobbyproject/service/PostService.java
+++ b/src/main/java/com/example/hobbyproject/service/PostService.java
@@ -8,9 +8,6 @@ import com.example.hobbyproject.model.PostDeleteInput;
 import com.example.hobbyproject.model.PostModel;
 import com.example.hobbyproject.model.PostUpdateInput;
 import com.example.hobbyproject.repository.PostRepository;
-
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,6 +18,7 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -105,7 +103,7 @@ public class PostService {
                 .orElseThrow(() -> new PostException(PostExceptionType.POST_NOT_FOUND));
 
         if (post.isDeleted()) {
-            throw new  PostException(PostExceptionType.ALREADY_DELETED);
+            throw new PostException(PostExceptionType.ALREADY_DELETED);
         }
 
         post.setDeleted(true);

--- a/src/main/java/com/example/hobbyproject/service/UserService.java
+++ b/src/main/java/com/example/hobbyproject/service/UserService.java
@@ -1,0 +1,192 @@
+package com.example.hobbyproject.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.example.hobbyproject.entity.Post;
+import com.example.hobbyproject.entity.PostLike;
+import com.example.hobbyproject.entity.User;
+import com.example.hobbyproject.exception.UserException;
+import com.example.hobbyproject.exception.UserExceptionType;
+import com.example.hobbyproject.model.*;
+import com.example.hobbyproject.repository.PostLikeRepository;
+import com.example.hobbyproject.repository.PostRepository;
+import com.example.hobbyproject.repository.UserRepository;
+import com.example.hobbyproject.utils.PasswordUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    // 특정 회원 정보 조회(보안상 비밀번호, 가입일, 회원 정보 수정일 노출 X)
+    public UserResponse getUserById(Long id) {
+
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        return UserResponse.of(user);
+    }
+
+    // 특정 회원이 작성한 글 목록 반환(삭제일과 삭제자 아이디는 보안상 내리지 않음, 작성자의 아이디와 이름만 내림)
+    @Transactional
+    public List<PostResponse> getPostsByUserId(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        List<Post> postList = postRepository.findByUser(user);
+
+        List<PostResponse> postResponseList = new ArrayList<>();
+
+        postList.stream().forEach((e) -> {
+            postResponseList.add(PostResponse.of(e));
+        });
+
+        return postResponseList;
+    }
+
+    // 회원 등록
+    public UserModel registerUser(UserInput userInput) {
+
+        Optional<User> existEmail = userRepository.findByEmail(userInput.getEmail());
+
+        // 이메일 중복
+        if (existEmail.isPresent()) {
+            throw new UserException(UserExceptionType.DUPLICATE_EMAIL);
+        }
+
+        //암호화하여 저장
+        String encryptPassword = PasswordUtils.hashPassword(userInput.getPassword());
+
+        // 새로운 사용자 엔터티 생성
+        User user = User.builder()
+                .email(userInput.getEmail())
+                .userName(userInput.getUserName())
+                .password(encryptPassword)
+                .phone(userInput.getPhone())
+                .regDate(LocalDateTime.now())
+                .build();
+
+        // 사용자 엔터티를 저장소에 저장
+        User savedUser = userRepository.save(user);
+
+        return UserModel.fromEntity(savedUser);
+    }
+
+    // 회원 수정
+    @Transactional
+    public UserModel updateUser(Long id, UserUpdate userUpdate) {
+        // 회원 id 조회
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        // 사용자 정보가 있는 경우에만 연락처를 업데이트.
+        user.setPhone(userUpdate.getPhone());
+        user.setUpdateDate(LocalDateTime.now());
+
+        // 업데이트된 유저 정보를 저장하고 반환.
+        User updatedUser = userRepository.save(user);
+        return UserModel.fromEntity(userRepository.save(user));
+    }
+
+    // 회원 비밀번호 수정
+    @Transactional
+    public UserModel updateUserPassword(Long id, UserInputPassword userInputPassword) {
+
+        User user = userRepository.findByIdAndPassword(id, userInputPassword.getPassword())
+                .orElseThrow(() -> new UserException(UserExceptionType.PASSWORD_NOT_MATCH));
+
+        //암호화되어서 저장
+        String newEncryptedPassword = PasswordUtils.hashPassword(userInputPassword.getNewPassword());
+        user.setPassword(newEncryptedPassword);
+
+        return UserModel.fromEntity(userRepository.save(user));
+    }
+
+    // 회원 삭제(성매매,불법도박 등 범죄 후기글. 회원 정보는 삭제하지만, 그 사람이 쓴 글은 추론 할 수 있게 남겨둠.)
+    public UserModel deleteUser(Long id) {
+
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        // 사용자 엔터티 삭제
+        userRepository.delete(user);
+
+        // 삭제된 사용자 정보를 UserModel로 변환하여 반환
+        return UserModel.fromEntity(user);
+    }
+
+    // 회원 ID(이메일)을 찾기(이름과 전화번호에 해당하는 이메일을 찾는다)
+    public UserResponse findUser(UserInputFind userInputFind) {
+
+        User user = userRepository.findByUserNameAndPhone(userInputFind.getUserName(), userInputFind.getPhone())
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        return UserResponse.of(user);
+    }
+
+    // 회원 비밀번호 초기화
+    public UserModel resetUserPassword(Long id) {
+
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        String resetPassword = PasswordUtils.getResetPassword();
+        String resetEncryptPassword = PasswordUtils.hashPassword(resetPassword);
+
+        user.setPassword(resetEncryptPassword);
+
+        User save = userRepository.save(user);
+
+        return UserModel.fromEntity(save);
+    }
+
+//        원래는 외부 API와 문자 연동해야함.
+//        String message = String.format("[%s]님의 임시 비밀번호가 [%s]로 초기화 되었습니다."
+//                , user.getUserName()
+//                , resetPassword);
+//        sendSMS(message);
+
+    // 내가 좋아요한  게시글을 보는 API
+    public List<PostLike> likePost(Long id) {
+
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        List<PostLike> postLikeList = postLikeRepository.findByUser(user);
+
+        return postLikeList;
+    }
+
+    /// JWT 토큰 발행 API(회원 이메일, 비밀번호 이용)
+    public UserLoginToken createToken(UserLogin userLogin) {
+
+        User user = userRepository.findByEmail(userLogin.getEmail())
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND));
+
+        if (!PasswordUtils.equalPassword(userLogin.getPassword(), user.getPassword())) {
+            throw new UserException(UserExceptionType.PASSWORD_NOT_MATCH);
+        }
+
+        String token = JWT.create()
+                .withExpiresAt(new Date())
+                .withClaim("user_id", user.getId())
+                .withSubject(user.getUserName())
+                .withIssuer(user.getEmail())
+                .sign(Algorithm.HMAC512("project".getBytes()));
+
+        return UserLoginToken.builder().token(token).build();
+    }
+}

--- a/src/main/java/com/example/hobbyproject/utils/JWTUtils.java
+++ b/src/main/java/com/example/hobbyproject/utils/JWTUtils.java
@@ -1,0 +1,22 @@
+package com.example.hobbyproject.utils;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class JWTUtils {
+
+    private static final String KEY = "project";
+
+    public static String getIssuer(String token) {
+
+        String issuer = JWT.require(Algorithm.HMAC512(KEY.getBytes()))
+                .build()
+                .verify(token)
+                .getIssuer();
+
+        return issuer;
+
+    }
+}

--- a/src/main/java/com/example/hobbyproject/utils/PasswordUtils.java
+++ b/src/main/java/com/example/hobbyproject/utils/PasswordUtils.java
@@ -1,0 +1,29 @@
+package com.example.hobbyproject.utils;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.UUID;
+
+@UtilityClass
+public class PasswordUtils {
+
+    private static final int RESET_PASSWORD_LENGTH = 10;
+    private static final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    // 입력한 패스워드를 해시된 패스워드랑 비교하는 함수
+    public static boolean equalPassword(String password, String encryptedPassword) {
+        return passwordEncoder.matches(password, encryptedPassword);
+    }
+
+    // 패스워드를 암호화하여 리턴하는 함수
+    public static String hashPassword(String password) {
+        return passwordEncoder.encode(password);
+    }
+
+    // 렌덤 난수 메소드
+    public static String getResetPassword() {
+        return UUID.randomUUID().toString().replaceAll("-", "").substring(0, RESET_PASSWORD_LENGTH);
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
1. 특정 회원 정보 조회(보안상 비밀번호, 가입일, 회원 정보 수정일 노출 X)
2. 특정 회원이 작성한 글 목록 반환
3. 회원 등록
4. 회원 정보 수정
5. 비밀번호 수정
6. 회원 삭제(성매매,불법도박 등 범죄 후기글. 회원 정보는 삭제하지만,
 그 사람이 쓴 글은 추론 할 수 있게 남겨둠)
7. 회원 ID(이메일)을 찾기(이름과 전화번호에 해당하는 이메일을 찾는다)
8. 회원 비밀번호 초기화
9. 내가 좋아요한 게시글을 보는 API(현재 별도로 좋아요 테이블을 구현한 상태 -> Post 테이블의 likes와 일치 하지 않아서 변경 필요)
10. JWT 토큰 발행 API(회원 이메일, 비밀번호 이용)

**TO-BE**
추후 클라이언트에게 제공되어야 하는 부분과 제공되어야 하지 않는 부분들 수정이 필요함.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [O] API 테스트
