### PR TITLE
refactor : 피드백 내용 반영(응집도 향상, 타입 형 변환, 엔드포인트 재설정, 비밀번호 초기화 변경)

### DIFF
--- a/src/main/java/com/example/hobbyproject/controller/CommentController.java
+++ b/src/main/java/com/example/hobbyproject/controller/CommentController.java
@@ -1,6 +1,5 @@
 package com.example.hobbyproject.controller;
 
-import com.example.hobbyproject.entity.Comment;
 import com.example.hobbyproject.error.CreateResponseError;
 import com.example.hobbyproject.model.comment.CommentRequest;
 import com.example.hobbyproject.model.comment.CommentUserInput;
@@ -18,37 +17,37 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/posts/comment")
+@RequestMapping("/api/comments")
 public class CommentController {
 
     private final CommentService commentService;
 
     // 특정 댓글 조회
     @GetMapping("/{commentId}")
-    public ResponseEntity<CommentUserInput> getComment(@PathVariable Long commentId) {
+    public ResponseEntity<?> getComment(@PathVariable Long commentId) {
         CommentUserInput comment = commentService.getComment(commentId);
         return ResponseEntity.ok(comment);
     }
 
     // 특정 게시물의 모든 댓글 조회
-    @GetMapping("/all/{postId}")
-    public ResponseEntity<List<CommentUserInput>> getCommentsByPostId(@PathVariable Long postId) {
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<List<?>> getCommentsByPostId(@PathVariable Long postId) {
         List<CommentUserInput> comments = commentService.getCommentsByPostId(postId);
         return ResponseEntity.ok(comments);
     }
 
     // 댓글 생성
-    @PostMapping("/create")
-    public ResponseEntity<Object> createComment(@RequestBody @Valid CommentRequest commentRequest) {
+    @PostMapping("/posts/{postId}")
+    public ResponseEntity<?> createComment(@RequestBody @Valid CommentRequest commentRequest) {
         CommentUserInput createdComment = commentService.createComment(commentRequest);
         return ResponseEntity.ok(createdComment);
     }
 
     // 댓글 수정
-    @PutMapping("update/{commentId}")
-    public ResponseEntity<Object> updateComment(@PathVariable Long commentId,
-                                                @RequestBody @Valid CommentRequest commentRequest,
-                                                Errors errors) {
+    @PutMapping("/{commentId}")
+    public ResponseEntity<?> updateComment(@PathVariable Long commentId,
+                                           @RequestBody @Valid CommentRequest commentRequest,
+                                           Errors errors) {
         // 필수 항목 미입력시 에러 처리(Object는 FieldError 반환)
         if (errors.hasErrors()) {
             List<CreateResponseError> responseErrors = new ArrayList<>();
@@ -64,8 +63,8 @@ public class CommentController {
     }
 
     // 댓글 삭제
-    @DeleteMapping("delete/{commentId}")
-    public ResponseEntity<Object> deleteComment(@PathVariable Long commentId) {
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);
         return ResponseEntity.ok("댓글이 삭제되었습니다.");
     }

--- a/src/main/java/com/example/hobbyproject/controller/UserController.java
+++ b/src/main/java/com/example/hobbyproject/controller/UserController.java
@@ -18,14 +18,14 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/user")
+@RequestMapping("/api/users")
 public class UserController {
 
     private final UserService userService;
 
     // 특정 회원 정보 조회(보안상 비밀번호, 가입일, 회원 정보 수정일 노출 X)
     @GetMapping("/{id}")
-    public ResponseEntity<UserResponse> getUserById(@PathVariable Long id) {
+    public ResponseEntity<?> getUserById(@PathVariable Long id) {
 
         UserResponse userResponse = userService.getUserById(id);
 
@@ -33,18 +33,16 @@ public class UserController {
     }
 
     // 특정 회원이 작성한 글 목록 반환
-    @GetMapping("/{list}/{id}")
-    public ResponseEntity<List<PostResponse>> getPostsByUserId(@PathVariable Long id) {
-
+    @GetMapping("/{lists}/{id}")
+    public ResponseEntity<?> getPostsByUserId(@PathVariable Long id) {
         List<PostResponse> postsByUserId = userService.getPostsByUserId(id);
-
         return ResponseEntity.ok(postsByUserId);
     }
 
     // 회원 등록
-    @PostMapping("/register")
-    public ResponseEntity<Object> registerUser(@RequestBody @Valid UserInput userInput,
-                                               Errors errors) {
+    @PostMapping
+    public ResponseEntity<?> registerUser(@RequestBody @Valid UserInput userInput,
+                                          Errors errors) {
 
         //필수 항목 미입력시 에러 처리(Object는 FieldError 반환)
         if (errors.hasErrors()) {
@@ -62,18 +60,20 @@ public class UserController {
 
     }
 
-    // 회원 정보 수정
-    @PutMapping("/update/{id}")
-    public ResponseEntity<UserModel> updateUser(@PathVariable Long id,
-                                                @RequestBody @Valid UserUpdate userUpdate) {
+    // 회원 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateUser(@PathVariable Long id,
+                                        @RequestBody @Valid UserUpdate userUpdate) {
 
         UserModel updatedUser = userService.updateUser(id, userUpdate);
 
         return ResponseEntity.ok(updatedUser);
     }
 
-    // 비밀번호 수정
-    @PatchMapping("/password/{id}")
+    // 비밀번호 수정(리소스의 부분적인 수정은 patch가 적절)
+    // 회원 엔터티에 여러 필드가 있고, 비밀번호만을 업데이트한다면 @PatchMapping
+    // 비밀번호만을 가지고 있는 경우에는 @PutMapping 적절.
+    @PatchMapping("/{id}/password")
     public ResponseEntity<?> updateUserPassword(@PathVariable Long id,
                                                 @RequestBody @Valid UserInputPassword userInputPassword,
                                                 Errors errors) {
@@ -93,15 +93,15 @@ public class UserController {
     }
 
     // 회원 삭제(성매매,불법도박 등 범죄 후기글. 회원 정보는 삭제하지만, 그 사람이 쓴 글은 추론 할 수 있게 남겨둠.
-    @DeleteMapping("/delete/{id}")
-    public ResponseEntity<UserModel> deleteUser(@PathVariable Long id) {
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteUser(@PathVariable Long id) {
         UserModel deletedUser = userService.deleteUser(id);
         return ResponseEntity.ok(deletedUser);
     }
 
     // 회원 ID(이메일)을 찾기(이름과 전화번호에 해당하는 이메일을 찾는다)
     @GetMapping("/find")
-    public ResponseEntity<UserResponse> findUser(@RequestBody UserInputFind userInputFind) {
+    public ResponseEntity<?> findUser(@RequestBody UserInputFind userInputFind) {
 
         UserResponse userResponse = userService.findUser(userInputFind);
 
@@ -109,9 +109,9 @@ public class UserController {
 
     }
 
-    // 회원 비밀번호 초기화
-    @GetMapping("/password/reset/{id}")
-    public ResponseEntity<UserModel> resetUserPassword(@PathVariable Long id) {
+    // 회원 비밀번호 초기화(리소스 수정에 더 가까워서 PUT 사용)
+    @PutMapping("/{id}/password/reset")
+    public ResponseEntity<?> resetUserPassword(@PathVariable Long id) {
 
         UserModel userModel = userService.resetUserPassword(id);
 
@@ -119,8 +119,8 @@ public class UserController {
     }
 
     // 내가 좋아요한 게시글을 보는 API
-    @GetMapping("/posts/like/{id}")
-    public ResponseEntity<List<PostLike>> likePost(@PathVariable Long id) {
+    @GetMapping("/{id}/posts/like")
+    public ResponseEntity<?> likePost(@PathVariable Long id) {
 
         List<PostLike> postLikeList = userService.likePost(id);
 
@@ -142,5 +142,6 @@ public class UserController {
         UserLoginToken token = userService.createToken(userLogin);
         return ResponseEntity.ok(token);
     }
+
 
 }

--- a/src/main/java/com/example/hobbyproject/repository/UserRepository.java
+++ b/src/main/java/com/example/hobbyproject/repository/UserRepository.java
@@ -9,10 +9,14 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    // 해당 이메일로 사용자를 조회
     Optional<User> findByEmail(String email);
 
     Optional<User> findByIdAndPassword(Long id, String password);
 
     // 회원 ID(이메일)을 찾기(이름과 전화번호에 해당하는 이메일을 찾는다)
     Optional<User> findByUserNameAndPhone(String userName, String phone);
+
+    // 중복된 이메일이 있는지 검증
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/hobbyproject/service/CommentService.java
+++ b/src/main/java/com/example/hobbyproject/service/CommentService.java
@@ -106,12 +106,11 @@ public class CommentService {
         return CommentUserInput.fromCommentEntity(updatedComment);
     }
 
-    //댓글 삭제
     @Transactional
     public void deleteComment(Long commentId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new PostException(COMMENT_NOT_FOUND));
-
+        // 댓글 삭제
         commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/example/hobbyproject/service/UserService.java
+++ b/src/main/java/com/example/hobbyproject/service/UserService.java
@@ -8,10 +8,10 @@ import com.example.hobbyproject.entity.User;
 import com.example.hobbyproject.exception.UserException;
 import com.example.hobbyproject.model.post.PostResponse;
 import com.example.hobbyproject.model.user.*;
-import com.example.hobbyproject.type.UserExceptionType;
 import com.example.hobbyproject.repository.PostLikeRepository;
 import com.example.hobbyproject.repository.PostRepository;
 import com.example.hobbyproject.repository.UserRepository;
+import com.example.hobbyproject.type.UserExceptionType;
 import com.example.hobbyproject.utils.PasswordUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +21,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -58,15 +57,17 @@ public class UserService {
         return postResponseList;
     }
 
+    // 중복된 이메일 검증
+    private void validateEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new UserException(UserExceptionType.DUPLICATE_EMAIL);
+        }
+    }
+
     // 회원 등록
     public UserModel registerUser(UserInput userInput) {
 
-        Optional<User> existEmail = userRepository.findByEmail(userInput.getEmail());
-
-        // 이메일 중복
-        if (existEmail.isPresent()) {
-            throw new UserException(UserExceptionType.DUPLICATE_EMAIL);
-        }
+        validateEmail(userInput.getEmail());
 
         //암호화하여 저장
         String encryptPassword = PasswordUtils.hashPassword(userInput.getPassword());


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS** 
1. 회원등록의 메서드 책임이 등록과 유효성 검증으로 두개 -> 응집도가 낮음
2. 회원 및 댓글의 전반적인 API 엔드포인트가 Restful 성격에 맞지 않게 동사의 형태로 작성되어 있었고, 순서도 달라 의미를 명확히 하지 못했음.
3. 특정 타입을 강제한 ResponseEntity가 다수였음.
4. 회원 비밀번호 초기화 API에서 @GetMapping을 사용했음.
5. 회원 삭제 오류 (외래 키 제약이 걸려있어 부모 행을 삭제할 때 자식 행도 함께 삭제되려고 하면서 오류가 발생)

**TO-BE**
 1. UserRepository에 boolean isExistedEmail 메서드를 추가 -> validateEmail 메소드를 별도로 구현 -> 회원등록 메서드의 책임 완화.
2. Restful 명명 규칙에 맞게 엔드포인트를 수정.
3. ResponseEntity를 보다 자유로운 형태로 수정하여 제네릭 타입을 ResponseEntity<?>로 변경.
4. 회원 비밀번호 초기화 API에서는 리소스 수정에 더 가까운 성격을 갖도록 @PutMapping으로 변경.
5. 삭제 테이블 수정
CREATE TABLE comment (
    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
    post_id     BIGINT NOT NULL,
    user_id     BIGINT NOT NULL,
    contents    VARCHAR(255) NOT NULL,
    reg_date    TIMESTAMP,
    update_date TIMESTAMP,
    CONSTRAINT fk_comment_post FOREIGN KEY (post_id) REFERENCES post (id) ON DELETE CASCADE,
    CONSTRAINT fk_comment_user FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE
);

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [O] API 테스트 
